### PR TITLE
Bump to Home Genie 1.1-beta525

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ CMD ["/sbin/my_init"]
 
 RUN apt-get update && apt-get install -y gdebi-core usbutils && apt-get clean -y
 
-ADD https://github.com/genielabs/HomeGenie/releases/download/v1.1-beta.525/homegenie-beta_1.1.r525_all.deb /tmp/
+ADD http://downloads.sourceforge.net/project/homegenie/homegenie-beta_1.1.r525_all.deb /tmp/
 
 RUN gdebi --non-interactive /tmp/homegenie-beta_1.1.r525_all.deb 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,9 @@ CMD ["/sbin/my_init"]
 
 RUN apt-get update && apt-get install -y gdebi-core usbutils && apt-get clean -y
 
-ADD http://downloads.sourceforge.net/project/homegenie/homegenie-beta_1.1.r515_all.deb /tmp/
+ADD https://github.com/genielabs/HomeGenie/releases/download/v1.1-beta.525/homegenie-beta_1.1.r525_all.deb /tmp/
 
-RUN gdebi --non-interactive /tmp/homegenie-beta_1.1.r515_all.deb 
+RUN gdebi --non-interactive /tmp/homegenie-beta_1.1.r525_all.deb 
 
 RUN mkdir /etc/service/homegenie
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM phusion/baseimage
 # Use baseimage-docker's init system.
 CMD ["/sbin/my_init"]
 
-RUN apt-get update && apt-get install -y gdebi-core usbutils && apt-get clean -y
+RUN apt-get update && apt-get install -y gdebi-core usbutils lirc liblircclient-dev && apt-get clean -y
 
 ADD http://downloads.sourceforge.net/project/homegenie/homegenie-beta_1.1.r525_all.deb /tmp/
 

--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ Automated build for HomeGenie.
 
 Changelog:
 
-2016.03.26 - Based on phusion/baseimage of Ubuntu 14.04.  Automatically downloads and installs HomeGenie 1.1beta-r515.
+2016.03.26 - Based on phusion/baseimage of Ubuntu 14.04.  Automatically downloads and installs HomeGenie 1.1beta-r525.


### PR DESCRIPTION
This PR covers the work to revise the Docker build process to use a newer version (1.1-beta525) of Home Genie.  It also pre-installs one of the implicit dependencies (LIRC) which didn't play well during the Docker build.